### PR TITLE
Change ros_environment to the rolling branch (#1089)

### DIFF
--- a/ros2.repos
+++ b/ros2.repos
@@ -170,7 +170,7 @@ repositories:
   ros/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: foxy
+    version: rolling
   ros/ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git


### PR DESCRIPTION
Otherwise, it claims to be foxy which clearly isn't correct.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>